### PR TITLE
fix: 体育课程名称数据提取优化

### DIFF
--- a/xk_spider/gui/workers.py
+++ b/xk_spider/gui/workers.py
@@ -204,10 +204,22 @@ class CourseFetchWorker(QThread):
         is_conflict = parse_bool_field(tc.get('isConflict'))
         is_chosen = parse_bool_field(tc.get('isChoose') or tc.get('isChosen'))
         
+        # 提取教师名和体育项目名
+        teacher_name = tc.get('teacherName') or tc.get('SKJS', '')
+        sport_name = tc.get('sportName', '')  # 体育课程特有字段
+        
+        # 如果有体育项目名，拼接到教师名后面
+        if sport_name:
+            display_teacher = f"{teacher_name} -- {sport_name}"
+        else:
+            display_teacher = teacher_name
+        
         return {
             'JXBID': tc.get('teachingClassID') or tc.get('JXBID', ''),
             'KCM': course_name,
-            'SKJS': tc.get('teacherName') or tc.get('SKJS', ''),
+            'SKJS': display_teacher,  # 教师名 + 体育项目名
+            'SKJS_RAW': teacher_name,  # 保留原始教师名（用于日志等）
+            'SPORT_NAME': sport_name,  # 保留体育项目名（用于后续处理）
             'SKSJ': tc.get('teachingPlace') or tc.get('classTime') or tc.get('SKSJ', ''),
             'KRL': parse_int_field(tc.get('classCapacity') or tc.get('KRL')),
             'YXRS': parse_int_field(tc.get('numberOfFirstVolunteer') or tc.get('YXRS')),


### PR DESCRIPTION
问题描述:
体育课程在课程卡片和列表中只显示教师名，无法区分具体的体育项目（如排球、羽毛球、篮球等）

解决方案:
1. 解析 API 返回的 sportName 字段（体育课程特有）
2. 将体育项目名拼接到教师名后面，格式：教师名 -- 体育项目名
3. 保留原始数据字段以便后续使用

修改内容:
- 在 _extract_course_info 函数中添加 sportName 字段解析
- SKJS 字段：显示用的拼接名称（如'罗斌 -- 排球（四）'）
- SKJS_RAW 字段：保留原始教师名（如'罗斌'）
- SPORT_NAME 字段：保留体育项目名（如'排球（四）'）

影响范围:
- 课程卡片显示
- 待抢列表显示
- 成功消息显示
- 对非体育课程无影响（向后兼容）

Closes #1